### PR TITLE
Add ability to override NPROC for test-cover

### DIFF
--- a/test-cover.sh
+++ b/test-cover.sh
@@ -18,7 +18,10 @@ do
   fi
 done
 
-NPROC=$(getconf _NPROCESSORS_ONLN)
+if [ "$NPROC" = "" ]; then
+  NPROC=$(getconf _NPROCESSORS_ONLN)
+fi
+
 echo "test-cover begin: concurrency $NPROC"
 go run .ci/gotestcover/gotestcover.go -race -covermode=atomic -coverprofile=profile.tmp -v -parallelpackages $NPROC $DIRS | tee $LOG
 


### PR DESCRIPTION
This adds the ability to override the NPROC when running test coverage.  This is helpful if you are on a system that you want to avoid being pegged by CPU as you run the tests.

cc @prateek @xichen2020 @cw9 @ben-lerner 