### PR TITLE
Fix unit tests passing when they should fail

### DIFF
--- a/test-cover.sh
+++ b/test-cover.sh
@@ -39,9 +39,12 @@ if [ "$TEST_EXIT" = "0" ]; then
   for DIR in $DIRS; do
     if cat $DIR/*_test.go | grep "// +build" | grep "big" &>/dev/null; then
       go test $TEST_FLAGS -tags noparallel -coverprofile $PROFILE_BIG $DIR | tee $LOG
-      TEST_EXIT=${PIPESTATUS[0]}
-      if [ "$TEST_EXIT" != "0" ]; then
-        break
+      # Only set TEST_EXIT if its already zero to be prevent overwriting non-zero exit codes
+      if [ "$TEST_EXIT" = "0" ]; then
+        TEST_EXIT=${PIPESTATUS[0]}
+      fi
+      if [ "${PIPESTATUS[0]}" != "0" ]; then
+        continue
       fi
       if [ -s $PROFILE_BIG ]; then
         cat $PROFILE_BIG | tail -n +1 >> $PROFILE_REG

--- a/test-cover.sh
+++ b/test-cover.sh
@@ -41,7 +41,7 @@ if [ "$TEST_EXIT" = "0" ]; then
       go test $TEST_FLAGS -tags noparallel -coverprofile $PROFILE_BIG $DIR | tee $LOG
       TEST_EXIT=${PIPESTATUS[0]}
       if [ "$TEST_EXIT" != "0" ]; then
-        continue
+        break
       fi
       if [ -s $PROFILE_BIG ]; then
         cat $PROFILE_BIG | tail -n +1 >> $PROFILE_REG

--- a/test-cover.sh
+++ b/test-cover.sh
@@ -31,27 +31,24 @@ TEST_FLAGS="-v -race -timeout 5m -covermode atomic"
 go run .ci/gotestcover/gotestcover.go $TEST_FLAGS -coverprofile $PROFILE_REG -parallelpackages $NPROC $DIRS | tee $LOG
 TEST_EXIT=${PIPESTATUS[0]}
 
-# Only run additional tests if previous tests exited clean so we don't overwrite
-# the TEST_EXIT variable
-if [ "$TEST_EXIT" = "0" ]; then
-  # run big tests one by one
-  echo "test-cover begin: concurrency 1, +big"
-  for DIR in $DIRS; do
-    if cat $DIR/*_test.go | grep "// +build" | grep "big" &>/dev/null; then
-      go test $TEST_FLAGS -tags noparallel -coverprofile $PROFILE_BIG $DIR | tee $LOG
-      # Only set TEST_EXIT if its already zero to be prevent overwriting non-zero exit codes
-      if [ "$TEST_EXIT" = "0" ]; then
-        TEST_EXIT=${PIPESTATUS[0]}
-      fi
-      if [ "${PIPESTATUS[0]}" != "0" ]; then
-        continue
-      fi
-      if [ -s $PROFILE_BIG ]; then
-        cat $PROFILE_BIG | tail -n +1 >> $PROFILE_REG
-      fi
+# run big tests one by one
+echo "test-cover begin: concurrency 1, +big"
+for DIR in $DIRS; do
+  if cat $DIR/*_test.go | grep "// +build" | grep "big" &>/dev/null; then
+    go test $TEST_FLAGS -tags noparallel -coverprofile $PROFILE_BIG $DIR | tee $LOG
+    BIG_TEST_EXIT=${PIPESTATUS[0]}
+    # Only set TEST_EXIT if its already zero to be prevent overwriting non-zero exit codes
+    if [ "$TEST_EXIT" = "0" ]; then
+      TEST_EXIT=$BIG_TEST_EXIT
     fi
-  done
-fi
+    if [ "$BIG_TEST_EXIT" != "0" ]; then
+      continue
+    fi
+    if [ -s $PROFILE_BIG ]; then
+      cat $PROFILE_BIG | tail -n +1 >> $PROFILE_REG
+    fi
+  fi
+done
 
 cat $PROFILE_REG | grep -v "_mock.go" > $TARGET
 


### PR DESCRIPTION
Right now if unit tests fail, but the "big" tests pass, then the TEST_EXIT variable gets clobbered and the tests will pass when they should have failed