### PR TITLE
Add --tests flag to gometalinter

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -9,7 +9,7 @@ install-glide:
 install-ci:
 	make install-vendor
 
-install-metalinter-internal:
+install-metalinter:
 	@which gometalinter > /dev/null || (go get -u github.com/alecthomas/gometalinter && \
 		go install github.com/alecthomas/gometalinter && gometalinter --install)
 	@which gometalinter > /dev/null || (echo "gometalinter install failed" && exit 1)

--- a/common.mk
+++ b/common.mk
@@ -9,7 +9,7 @@ install-glide:
 install-ci:
 	make install-vendor
 
-install-metalinter:
+install-metalinter-internal:
 	@which gometalinter > /dev/null || (go get -u github.com/alecthomas/gometalinter && \
 		go install github.com/alecthomas/gometalinter && gometalinter --install)
 	@which gometalinter > /dev/null || (echo "gometalinter install failed" && exit 1)

--- a/metalint.sh
+++ b/metalint.sh
@@ -13,4 +13,4 @@ if [[ ! -f $exclude_file ]]; then
   exit 1
 fi
 
-! gometalinter --config $config_file --vendor ./... | egrep -v -f $exclude_file
+! gometalinter --tests --config $config_file --vendor ./... | egrep -v -f $exclude_file


### PR DESCRIPTION
Some linters require the --tests flag to be passed to gometalinter in order to lint tests