### PR TITLE
[gometalinter] Install version 2.0.0 of gometalinter by default

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1,4 +1,4 @@
-metalinter_version  := 0262fb20957a4c2d3bb7c834a6a125ae3884a2c6
+metalinter_version  := v2.0.0
 badtime_version     := a1d80fa39058e2de323bf0b54d47bfab92e9a97f
 
 install-vendor: install-glide


### PR DESCRIPTION
cc @prateek 

`gometalinter` released [version 2](https://github.com/alecthomas/gometalinter/releases/tag/v2.0.0) which [promises to contain performance improvements](https://groups.google.com/forum/#!topic/golang-nuts/8XvNgKtUdIY). I've run it on some of our repos so far without issue. The release notes say that most configurations should not need to change and that appears to be the case with us.

Something to note is that they are moving towards releasing binary packages and will be deprecating support for managing linter installation. I'm guessing that means we will need to be responsible for installing the linters we need ourselves, but I don't see that as being a big issue and we can cross that bridge when we come to it.