### PR TITLE
Fix big tests not removing first line of coverage output

### DIFF
--- a/test-cover.sh
+++ b/test-cover.sh
@@ -45,7 +45,7 @@ for DIR in $DIRS; do
       continue
     fi
     if [ -s $PROFILE_BIG ]; then
-      cat $PROFILE_BIG | tail -n +1 >> $PROFILE_REG
+      cat $PROFILE_BIG | tail -n +2 >> $PROFILE_REG
     fi
   fi
 done


### PR DESCRIPTION
The first line of coverage output is the `mode: atomic` line which when concatenated together should only appear once at the very top.