### PR TITLE
Rerun mockclean after the vendor path is stripped

### DIFF
--- a/auto-gen.sh
+++ b/auto-gen.sh
@@ -54,11 +54,6 @@ mocks_cleanup() {
         if ls $MOCKS &> /dev/null; then
             for FILE in $(ls $MOCKS);
             do
-                # NB(prateek): running mockclean makes mock-gen idempotent.
-                basePkg=$(echo $DIR | sed -e "s@${GOPATH}/src/@@g")
-                mockclean -pkg $basePkg -out $FILE -in $FILE
-                gofmt -w $FILE
-
                 add_license $FILE $DIR
 
                 # NB(xichen): there is an open issue (https://github.com/golang/mock/issues/30)
@@ -71,6 +66,12 @@ mocks_cleanup() {
 
                 # Strip GOPATH from the source file path
                 sed "s|Source: $GOPATH/src/\(.*\.go\)|Source: \1|" $FILE > $FILE.tmp && mv $FILE.tmp $FILE
+
+                # NB(prateek): running mockclean makes mock-gen idempotent.
+                # NB(xichen): mockclean should be run after the vendor path is stripped.
+                basePkg=$(echo $DIR | sed -e "s@${GOPATH}/src/@@g")
+                mockclean -pkg $basePkg -out $FILE -in $FILE
+                gofmt -w $FILE
             done
         fi
     done


### PR DESCRIPTION
cc @prateek 

We should run mockclean after the vendor path is stripped. Otherwise if the generated mocks uses a *vendored* 3rd party import path, it'll be grouped together alongside the user imports, which is not what we want.