### PR TITLE
[WIP] Extract big unit tests into a separate target

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -7,6 +7,7 @@ coverage_html        := coverage.html
 junit_xml            := junit.xml
 convert_test_data    := .ci/convert-test-data.sh
 test                 := .ci/test-cover.sh
+test_big             := .ci/test-big-cover.sh
 test_one_integration := .ci/test-one-integration.sh
 test_ci_integration  := .ci/test-integration.sh
 test_log             := test.log
@@ -45,6 +46,10 @@ test-base:
 	@which go-junit-report > /dev/null || go get -u github.com/sectioneight/go-junit-report
 	$(test) $(coverfile) | tee $(test_log)
 
+test-base-big:
+	@which go-junit-report > /dev/null || go get -u github.com/sectioneight/go-junit-report
+	$(test_big) $(coverfile) | tee $(test_log)
+
 test-base-xml: test-base
 	go-junit-report < $(test_log) > $(junit_xml)
 	gocov convert $(coverfile) | gocov-xml > $(coverage_xml)
@@ -63,6 +68,10 @@ test-base-single-integration:
 	$(test_one_integration) $(name)
 
 test-base-ci-unit: test-base
+	@which goveralls > /dev/null || go get -u -f github.com/m3db/goveralls
+	goveralls -coverprofile=$(coverfile) -service=semaphore || (echo -e "Coveralls failed" && exit 1)
+
+test-base-ci-big-unit: test-base-big
 	@which goveralls > /dev/null || go get -u -f github.com/m3db/goveralls
 	goveralls -coverprofile=$(coverfile) -service=semaphore || (echo -e "Coveralls failed" && exit 1)
 

--- a/test-big-cover.sh
+++ b/test-big-cover.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+. "$(dirname $0)/variables.sh"
+
+set -ex
+
+TARGET=${1:-profile.cov}
+LOG=${2:-test.log}
+
+rm $TARGET &>/dev/null || true
+echo "mode: count" > $TARGET
+echo "" > $LOG
+
+DIRS=""
+for DIR in $SRC;
+do
+  if ls $DIR/*_test.go &> /dev/null; then
+    DIRS="$DIRS $DIR"
+  fi
+done
+
+PROFILE_REG="profile_reg.tmp"
+PROFILE_BIG="profile_big.tmp"
+
+TEST_FLAGS="-v -race -timeout 5m -covermode atomic"
+TEST_EXIT="0"
+
+# run big tests one by one
+echo "test-cover begin: concurrency 1, +big"
+for DIR in $DIRS; do
+  if cat $DIR/*_test.go | grep "// +build" | grep "big" &>/dev/null; then
+    # extract only the tests marked "big"
+    BIG_TESTS=$(cat <(go test $DIR -tags big -list '.*' | grep -v '^ok' ) \
+                    <(go test $DIR -list '.*' | grep -v '^ok' )           \
+                    | sort | uniq -u | paste -sd'|' -)
+    go test $TEST_FLAGS -tags big -run $BIG_TESTS -coverprofile $PROFILE_BIG $DIR | tee $LOG
+    BIG_TEST_EXIT=${PIPESTATUS[0]}
+    # Only set TEST_EXIT if its already zero to be prevent overwriting non-zero exit codes
+    if [ "$TEST_EXIT" = "0" ]; then
+      TEST_EXIT=$BIG_TEST_EXIT
+    fi
+    if [ "$BIG_TEST_EXIT" != "0" ]; then
+      continue
+    fi
+    if [ -s $PROFILE_BIG ]; then
+      cat $PROFILE_BIG | tail -n +2 >> $PROFILE_REG
+    fi
+  fi
+done
+
+cat $PROFILE_REG | grep -v "_mock.go" > $TARGET
+
+find . -not -path '*/vendor/*' | grep \\.tmp$ | xargs -I{} rm {}
+echo "test-cover result: $TEST_EXIT"
+
+exit $TEST_EXIT

--- a/test-big-cover.sh
+++ b/test-big-cover.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . "$(dirname $0)/variables.sh"
 
-set -ex
+set -e
 
 TARGET=${1:-profile.cov}
 LOG=${2:-test.log}
@@ -29,8 +29,8 @@ echo "test-cover begin: concurrency 1, +big"
 for DIR in $DIRS; do
   if cat $DIR/*_test.go | grep "// +build" | grep "big" &>/dev/null; then
     # extract only the tests marked "big"
-    BIG_TESTS=$(cat <(go test $DIR -tags big -list '.*' | grep -v '^ok' ) \
-                    <(go test $DIR -list '.*' | grep -v '^ok' )           \
+    BIG_TESTS=$(cat <(go test $DIR -tags big -list '.*' | grep -v '^ok' | grep -v 'no test files' ) \
+                    <(go test $DIR -list '.*' | grep -v '^ok' | grep -v 'no test files')            \
                     | sort | uniq -u | paste -sd'|' -)
     go test $TEST_FLAGS -tags big -run $BIG_TESTS -coverprofile $PROFILE_BIG $DIR | tee $LOG
     BIG_TEST_EXIT=${PIPESTATUS[0]}

--- a/test-big-cover.sh
+++ b/test-big-cover.sh
@@ -47,7 +47,7 @@ for DIR in $DIRS; do
   fi
 done
 
-cat $PROFILE_REG | grep -v "_mock.go" > $TARGET
+cat $PROFILE_REG | grep -v "_mock.go" >> $TARGET
 
 find . -not -path '*/vendor/*' | grep \\.tmp$ | xargs -I{} rm {}
 echo "test-cover result: $TEST_EXIT"

--- a/test-cover.sh
+++ b/test-cover.sh
@@ -31,25 +31,6 @@ TEST_FLAGS="-v -race -timeout 5m -covermode atomic"
 go run .ci/gotestcover/gotestcover.go $TEST_FLAGS -coverprofile $PROFILE_REG -parallelpackages $NPROC $DIRS | tee $LOG
 TEST_EXIT=${PIPESTATUS[0]}
 
-# run big tests one by one
-echo "test-cover begin: concurrency 1, +big"
-for DIR in $DIRS; do
-  if cat $DIR/*_test.go | grep "// +build" | grep "big" &>/dev/null; then
-    go test $TEST_FLAGS -tags big -coverprofile $PROFILE_BIG $DIR | tee $LOG
-    BIG_TEST_EXIT=${PIPESTATUS[0]}
-    # Only set TEST_EXIT if its already zero to be prevent overwriting non-zero exit codes
-    if [ "$TEST_EXIT" = "0" ]; then
-      TEST_EXIT=$BIG_TEST_EXIT
-    fi
-    if [ "$BIG_TEST_EXIT" != "0" ]; then
-      continue
-    fi
-    if [ -s $PROFILE_BIG ]; then
-      cat $PROFILE_BIG | tail -n +2 >> $PROFILE_REG
-    fi
-  fi
-done
-
 cat $PROFILE_REG | grep -v "_mock.go" > $TARGET
 
 find . -not -path '*/vendor/*' | grep \\.tmp$ | xargs -I{} rm {}


### PR DESCRIPTION
- extract big unit tests as a separate target,
- don't re-run non-big tests when executing big tests