### PR TITLE
Re-work integration script to include coverage reporting, separate big unit tests

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -7,6 +7,7 @@ coverage_html        := coverage.html
 junit_xml            := junit.xml
 convert_test_data    := .ci/convert-test-data.sh
 test                 := .ci/test-cover.sh
+test_big             := .ci/test-big-cover.sh
 test_one_integration := .ci/test-one-integration.sh
 test_ci_integration  := .ci/test-integration.sh
 test_log             := test.log
@@ -44,6 +45,10 @@ install-util-mockclean:
 test-base:
 	@which go-junit-report > /dev/null || go get -u github.com/sectioneight/go-junit-report
 	$(test) $(coverfile) | tee $(test_log)
+
+test-big-base:
+	@which go-junit-report > /dev/null || go get -u github.com/sectioneight/go-junit-report
+	$(test_big) $(coverfile) | tee $(test_log)
 
 test-base-xml: test-base
 	go-junit-report < $(test_log) > $(junit_xml)

--- a/test-big-cover.sh
+++ b/test-big-cover.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+. "$(dirname $0)/variables.sh"
+
+set -e
+
+TARGET=${1:-cover.out}
+LOG=${2:-test.log}
+
+rm $TARGET &>/dev/null || true
+echo "mode: count" > $TARGET
+echo "" > $LOG
+
+DIRS=""
+for DIR in $SRC;
+do
+  if ls $DIR/*_test.go &> /dev/null; then
+    DIRS="$DIRS $DIR"
+  fi
+done
+
+PROFILE_REG="profile_reg.tmp"
+PROFILE_BIG="profile_big.tmp"
+TEST_EXIT=0
+
+# run big tests one by one
+echo "test-cover begin: concurrency 1, +big"
+for DIR in $DIRS; do
+  if cat $DIR/*_test.go | grep "// +build" | grep "big" &>/dev/null; then
+    # extract only the tests marked "big"
+    BIG_TESTS=$(cat <(go test $DIR -tags big -list '.*' | grep -v '^ok' | grep -v 'no test files' ) \
+                    <(go test $DIR -list '.*' | grep -v '^ok' | grep -v 'no test files')            \
+                    | sort | uniq -u | paste -sd'|' -)
+    go test $TEST_FLAGS -tags big -run $BIG_TESTS -coverprofile $PROFILE_BIG $DIR | tee $LOG
+    BIG_TEST_EXIT=${PIPESTATUS[0]}
+    # Only set TEST_EXIT if its already zero to be prevent overwriting non-zero exit codes
+    if [ "$TEST_EXIT" = "0" ]; then
+      TEST_EXIT=$BIG_TEST_EXIT
+    fi
+    if [ "$BIG_TEST_EXIT" != "0" ]; then
+      continue
+    fi
+    if [ -s $PROFILE_BIG ]; then
+      cat $PROFILE_BIG | tail -n +2 >> $PROFILE_REG
+    fi
+  fi
+done
+
+cat $PROFILE_REG | grep -v "_mock.go" > $TARGET
+
+find . -not -path '*/vendor/*' | grep \\.tmp$ | xargs -I{} rm {}
+echo "test-cover result: $TEST_EXIT"
+
+exit $TEST_EXIT

--- a/test-big-cover.sh
+++ b/test-big-cover.sh
@@ -7,7 +7,7 @@ TARGET=${1:-cover.out}
 LOG=${2:-test.log}
 
 rm $TARGET &>/dev/null || true
-echo "mode: count" > $TARGET
+echo "mode: atomic" > $TARGET
 echo "" > $LOG
 
 DIRS=""
@@ -23,6 +23,7 @@ PROFILE_BIG="profile_big.tmp"
 TEST_EXIT=0
 
 # run big tests one by one
+TEST_FLAGS="-v -race -timeout 5m -covermode atomic"
 echo "test-cover begin: concurrency 1, +big"
 for DIR in $DIRS; do
   if cat $DIR/*_test.go | grep "// +build" | grep "big" &>/dev/null; then

--- a/test-big-cover.sh
+++ b/test-big-cover.sh
@@ -31,8 +31,7 @@ for DIR in $DIRS; do
     BIG_TESTS=$(cat <(go test $DIR -tags big -list '.*' | grep -v '^ok' | grep -v 'no test files' ) \
                     <(go test $DIR -list '.*' | grep -v '^ok' | grep -v 'no test files')            \
                     | sort | uniq -u | paste -sd'|' -)
-    go test $TEST_FLAGS -tags big -run $BIG_TESTS -coverpkg $(go list ./... | paste -sd, -) \
-      -coverprofile $PROFILE_BIG $DIR | tee $LOG
+    go test $TEST_FLAGS -tags big -run $BIG_TESTS -coverprofile $PROFILE_BIG $DIR | tee $LOG
     BIG_TEST_EXIT=${PIPESTATUS[0]}
     # Only set TEST_EXIT if its already zero to be prevent overwriting non-zero exit codes
     if [ "$TEST_EXIT" = "0" ]; then

--- a/test-big-cover.sh
+++ b/test-big-cover.sh
@@ -30,7 +30,8 @@ for DIR in $DIRS; do
     BIG_TESTS=$(cat <(go test $DIR -tags big -list '.*' | grep -v '^ok' | grep -v 'no test files' ) \
                     <(go test $DIR -list '.*' | grep -v '^ok' | grep -v 'no test files')            \
                     | sort | uniq -u | paste -sd'|' -)
-    go test $TEST_FLAGS -tags big -run $BIG_TESTS -coverprofile $PROFILE_BIG $DIR | tee $LOG
+    go test $TEST_FLAGS -tags big -run $BIG_TESTS -coverpkg $(go list ./... | paste -sd, -) \
+      -coverprofile $PROFILE_BIG $DIR | tee $LOG
     BIG_TEST_EXIT=${PIPESTATUS[0]}
     # Only set TEST_EXIT if its already zero to be prevent overwriting non-zero exit codes
     if [ "$TEST_EXIT" = "0" ]; then

--- a/test-cover.sh
+++ b/test-cover.sh
@@ -25,7 +25,6 @@ fi
 echo "test-cover begin: concurrency $NPROC"
 
 PROFILE_REG="profile_reg.tmp"
-PROFILE_BIG="profile_big.tmp"
 
 TEST_FLAGS="-v -race -timeout 5m -covermode atomic"
 go run .ci/gotestcover/gotestcover.go $TEST_FLAGS -coverprofile $PROFILE_REG -parallelpackages $NPROC $DIRS | tee $LOG

--- a/test-cover.sh
+++ b/test-cover.sh
@@ -31,29 +31,6 @@ TEST_FLAGS="-v -race -timeout 5m -covermode atomic"
 go run .ci/gotestcover/gotestcover.go $TEST_FLAGS -coverprofile $PROFILE_REG -parallelpackages $NPROC $DIRS | tee $LOG
 TEST_EXIT=${PIPESTATUS[0]}
 
-# run big tests one by one
-echo "test-cover begin: concurrency 1, +big"
-for DIR in $DIRS; do
-  if cat $DIR/*_test.go | grep "// +build" | grep "big" &>/dev/null; then
-    # extract only the tests marked "big"
-    BIG_TESTS=$(cat <(go test $DIR -tags big -list '.*' | grep -v '^ok' | grep -v 'no test files' ) \
-                    <(go test $DIR -list '.*' | grep -v '^ok' | grep -v 'no test files')            \
-                    | sort | uniq -u | paste -sd'|' -)
-    go test $TEST_FLAGS -tags big -run $BIG_TESTS -coverprofile $PROFILE_BIG $DIR | tee $LOG
-    BIG_TEST_EXIT=${PIPESTATUS[0]}
-    # Only set TEST_EXIT if its already zero to be prevent overwriting non-zero exit codes
-    if [ "$TEST_EXIT" = "0" ]; then
-      TEST_EXIT=$BIG_TEST_EXIT
-    fi
-    if [ "$BIG_TEST_EXIT" != "0" ]; then
-      continue
-    fi
-    if [ -s $PROFILE_BIG ]; then
-      cat $PROFILE_BIG | tail -n +2 >> $PROFILE_REG
-    fi
-  fi
-done
-
 cat $PROFILE_REG | grep -v "_mock.go" > $TARGET
 
 find . -not -path '*/vendor/*' | grep \\.tmp$ | xargs -I{} rm {}

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -6,21 +6,28 @@ set -e
 TAGS="integration"
 DIR="integration"
 INTEGRATION_TIMEOUT=${INTEGRATION_TIMEOUT:-10m}
+COVERFILE=${COVERFILE:-cover.out}
+COVERMODE=count
+
+echo "mode: ${COVERMODE}" > $COVERFILE
 
 # compile the integration test binary
-go test -test.c -test.tags=${TAGS} ./${DIR}
+go test -test.c -test.tags=${TAGS} -test.covermode ${COVERMODE} \
+  -test.coverpkg $(go list ./... | paste -sd, -) ./${DIR}
 
 # list the tests
-TESTS=$(./integration.test -test.v -test.short | grep RUN | tr -s " " | cut -d ' ' -f 3)
+TESTS=$(./integration.test -test.list '.*')
 
 # execute tests one by one for isolation
 for TEST in $TESTS; do
-  ./integration.test -test.v -test.run $TEST -test.timeout $INTEGRATION_TIMEOUT ./integration
+  ./integration.test -test.v -test.run $TEST -test.coverprofile temp_${COVERFILE} \
+  -test.timeout $INTEGRATION_TIMEOUT ./integration
   TEST_EXIT=$?
   if [ "$TEST_EXIT" != "0" ]; then
     echo "$TEST failed"
     exit $TEST_EXIT
   fi
+  cat temp_${COVERFILE} | grep -v '_mock.go' | grep -v "mode: " >> ${COVERFILE}
   sleep 0.1
 done
 

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -16,7 +16,9 @@ go test -test.c -test.tags=${TAGS} -test.covermode ${COVERMODE} \
   -test.coverpkg $(go list ./... | paste -sd, -) ./${DIR}
 
 # list the tests
-TESTS=$(./integration.test -test.list '.*')
+TESTS=$(./integration.test -test.v -test.short | grep RUN | tr -s " " | cut -d ' ' -f 3)
+# can use the version below once the minimum version we use is go1.9
+# TESTS=$(./integration.test -test.list '.*')
 
 # execute tests one by one for isolation
 for TEST in $TESTS; do

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -13,7 +13,7 @@ echo "mode: ${COVERMODE}" > $COVERFILE
 
 # compile the integration test binary
 go test -test.c -test.tags=${TAGS} -test.covermode ${COVERMODE} \
-  -test.coverpkg $(go list ./... | paste -sd, -) ./${DIR}
+  -test.coverpkg $(go list ./... |  grep -v /vendor/ | paste -sd, -) ./${DIR}
 
 # list the tests
 TESTS=$(./integration.test -test.v -test.short | grep RUN | tr -s " " | cut -d ' ' -f 3)


### PR DESCRIPTION
- include coverage reporting in integration tests
- separate `big` unit tests as a separate make target, include verbose coverage information 
/cc @richardartoul @jeromefroe @xichen2020 