### PR TITLE
Faster generated protobuf code

### DIFF
--- a/proto-gen.sh
+++ b/proto-gen.sh
@@ -8,6 +8,6 @@ for i in "$PROTO_SRC"/*; do
 
 	if ls $i/*.proto > /dev/null 2>&1; then
 			echo "generating from $i"
-			protoc -I$i --gofast_out=$i $i/*.proto
+			protoc -I$GOPATH/src/github.com/gogo/protobuf/gogoproto -I$PROTO_SRC --gogofaster_out=$PROTO_SRC $i/*.proto
 	fi
 done

--- a/proto-gen.sh
+++ b/proto-gen.sh
@@ -8,6 +8,6 @@ for i in "$PROTO_SRC"/*; do
 
 	if ls $i/*.proto > /dev/null 2>&1; then
 			echo "generating from $i"
-			protoc -I$GOPATH/src/github.com/gogo/protobuf/gogoproto -I$PROTO_SRC --gogofaster_out=$PROTO_SRC $i/*.proto
+			protoc -I$GOPATH/src --gogofaster_out=$GOPATH/src $i/*.proto
 	fi
 done


### PR DESCRIPTION
cc @prateek @cw9 @jeromefroe 

This PR uses the `gogofaster` plugin to generate protobuf files, which claimed to be faster than `gofast` (I haven't tested this myself). Also changed the include path so proto files can import other proto files in other packages.