### PR TITLE
Exclude benchmarks from integration tests

### DIFF
--- a/variables.sh
+++ b/variables.sh
@@ -32,7 +32,7 @@ export -f filter_cover_profile
 function generate_dummy_coverage_file() {
   local package_name=$1
   local build_tag=$2
-go list ./... | grep -v vendor | grep -v "\/main$" | grep -v "\/${package_name}" > repo_packages.out
+go list ./... | grep -v vendor | grep -v "\/main$" | grep -v "\/benchmark\/" | grep -v "\/${package_name}" > repo_packages.out
 INPUT_FILE=./repo_packages.out python <<END
 import os
 input_file_path = os.environ['INPUT_FILE']


### PR DESCRIPTION
Benchmarks are typically standalone runnable programs that live in a `main` package. When running `./test-integration.sh`, it complains about something similar to the following:
```
Generating dummy integration file with all the packages listed for coverage
integration/coverage_imports.go:45:3: import "github.com/m3db/m3db/src/coordinator/benchmark/read" is a program, not an importable package
...
```

Not sure if there is a more elegant approach to avoiding this error.
