### PR TITLE
Remove current proto path include

### DIFF
--- a/proto-gen.sh
+++ b/proto-gen.sh
@@ -8,6 +8,6 @@ for i in "$PROTO_SRC"/*; do
 
 	if ls $i/*.proto > /dev/null 2>&1; then
 			echo "generating from $i"
-			protoc -I$i --gogofaster_out=plugins=grpc:$GOPATH/src --proto_path=$i:$GOPATH/src:$GOPATH/src/github.com/m3db/m3db/vendor $i/*.proto
+			protoc --gogofaster_out=plugins=grpc:$GOPATH/src --proto_path=$GOPATH/src:$GOPATH/src/github.com/m3db/m3db/vendor $i/*.proto
 	fi
 done


### PR DESCRIPTION
cc @cw9 

This PR removes the current path from the include path as this seems to cause import conflicts when one proto file needs to import another proto package.