### PR TITLE
Nerd0/prep semaphore builds

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -23,7 +23,15 @@ install-glide:
 		@which glide > /dev/null || (go get -u github.com/Masterminds/glide && cd $(GOPATH)/src/github.com/Masterminds/glide && git checkout v0.12.3 && go install)
 		@glide -version > /dev/null || (echo "Glide install failed" && exit 1)
 
+prep-semaphore:
+	[ -z "$SEMAPHORE" ] || (sudo swapoff -a && \
+		sudo dd if=/dev/zero of=/swapfile bs=1M count=1024 && \
+		sudo mkswap /swapfile && \
+		sudo swapon /swapfile && \
+		for s in cassandra elasticsearch memcached mongod postgresql sphinxsearch rabbitmq-server; do sudo service $s stop; done)
+
 install-ci:
+	make prep-semaphore
 	make install-vendor
 
 install-metalinter:


### PR DESCRIPTION
Turning on swap could allow us to run integration tests that require large amounts of memory on semaphore instances with low amounts of RAM. This would allow us to use the native docker platforms with semaphore