### PR TITLE
[buildkite] Collapse glide by default

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -20,7 +20,9 @@ validate-gopath:
 	@stat $(GOPATH) > /dev/null
 
 install-vendor: install-glide validate-gopath
-	@echo Installing glide deps
+	# collapse in buildkite by default
+	@echo "--- Install glide deps"
+	@echo "Installing glide deps"
 	PATH=$(GOPATH)/bin:$(PATH) GOPATH=$(GOPATH) glide --debug install
 
 install-glide:


### PR DESCRIPTION
Glide output is useless unless there's an error; this diff follows buildkite's [advice](https://buildkite.com/docs/pipelines/managing-log-output) to collapse the glide output by default.

[Here's](https://buildkite.com/uberopensource/m3/builds/225#05154255-e079-485a-80b0-2a036cecd917) a sample build showing this at work.