### PR TITLE
[cover] don't clobber coverage output

### DIFF
--- a/test-cover.sh
+++ b/test-cover.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 source "$(dirname $0)/variables.sh"
 

--- a/test-cover.sh
+++ b/test-cover.sh
@@ -40,7 +40,7 @@ mkdir -p $COVER_TMPDIR
 # Output each package's coverage result to a "friendly" file name (anything
 # that's not a character gets changed to '_'). Then combine those serially into
 # one result to not corrupt test output. Map reduce in bash, yolo.
-<<<"$TESTS" xargs -P $NPROC -n1 -I{} sh -c "NAME=\$(<<<{} sed 's/[^a-z]/_/g'); go test -v -race -timeout 5m -covermode=atomic -coverprofile=${COVER_TMPDIR}/\$NAME {} | tee -a $LOG"
+<<<"$TESTS" xargs -P $NPROC -n1 -I{} sh -c "NAME=\$(echo {} | sed 's/[^a-z]/_/g'); go test -v -race -timeout 5m -covermode=atomic -coverprofile=${COVER_TMPDIR}/\$NAME {} | tee -a $LOG"
 TEST_EXIT=$?
 
 find "$COVER_TMPDIR" -type f | while read -r F; do


### PR DESCRIPTION
We had previously been writing coverage results to a single file from
multiple processes and corrupting output. This serializes writing of
smaller per-package files to a single global file.