### PR TITLE
Exclude node_modules from output of find_dirs

### DIFF
--- a/variables.sh
+++ b/variables.sh
@@ -12,7 +12,7 @@ if [ "$SRC_ROOT" != "" ]; then
 fi
 
 find_dirs() {
-  find $FIND_ROOT -maxdepth 10 -not -path '*/.git*' -not -path '*/.ci*' -not -path '*/_*' -not -path '*/vendor*' -not -path '*/ui*' -not -path '*/integration*' -type d
+  find $FIND_ROOT -maxdepth 10 -not -path '*/.git*' -not -path '*/.ci*' -not -path '*/_*' -not -path '*/vendor*' -not -path '*/ui*' -not -path '*/integration*' -not -path '*/node_modules*' -type d
 }
 
 BASE_SRC=$(find_dirs)
@@ -25,18 +25,18 @@ filter_cover_profile() {
   local input_profile_file=$1
   local output_file=$2
   local exclude_file=$3
-  if [ -z $input_profile_file ] ; then
+  if [ -z $input_profile_file ]; then
     echo 'input_profile_file (i.e. $1) is not set'
     exit 1
   fi
-  if [ -z $output_file ] ; then
+  if [ -z $output_file ]; then
     echo 'output_file (i.e. $2) is not set'
     exit 1
   fi
-  if [ ! -z $exclude_file ] && [ -f $exclude_file ] ; then
-    cat $input_profile_file | egrep -v -f $exclude_file | grep -v 'mode:' >> $output_file
+  if [ ! -z $exclude_file ] && [ -f $exclude_file ]; then
+    cat $input_profile_file | egrep -v -f $exclude_file | grep -v 'mode:' >>$output_file
   else
-    cat $input_profile_file | grep -v "_mock.go" | grep -v 'mode:' >> $output_file
+    cat $input_profile_file | grep -v "_mock.go" | grep -v 'mode:' >>$output_file
   fi
 }
 
@@ -47,8 +47,8 @@ export -f filter_cover_profile
 function generate_dummy_coverage_file() {
   local package_name=$1
   local build_tag=$2
-go list ./$FIND_ROOT/... | grep -v vendor | grep -v "\/main$" | grep -v "\/${package_name}" > repo_packages.out
-INPUT_FILE=./repo_packages.out python <<END
+  go list ./$FIND_ROOT/... | grep -v vendor | grep -v "\/main$" | grep -v "\/${package_name}" >repo_packages.out
+  INPUT_FILE=./repo_packages.out python <<END
 import os
 input_file_path = os.environ['INPUT_FILE']
 input_file = open(input_file_path)
@@ -83,8 +83,7 @@ export -f generate_dummy_coverage_file
 # NB: generated subsets do not necessarily get grouped in the same order as the original list
 # (as seen in the example above)
 
-function pick_subset()
-{
+function pick_subset() {
   local input_to_split=$1
   local __result=$2
   local split_num=$3
@@ -92,29 +91,30 @@ function pick_subset()
 
   # defaulting to doing the sane thing w/o a warning
   if [ -z $split_num ] &&
-     [ -z $split_total ] ; then
+    [ -z $split_total ]; then
     eval $__result="'$input_to_split'"
     return 0
   fi
 
   local split_output
   if [[ $split_num =~ ^[0-9]+$ ]] &&
-     [[ $split_total =~ ^[0-9]+$ ]]   &&
-     (( split_num < split_total )) ; then
-       split_output=$(echo $input_to_split       \
-         | tr ' ' '\n'                           \
-         | sort                                  \
-         | awk "NR%${split_total}==${split_num}" \
-         | tr '\n' ' '                           \
-       )
+    [[ $split_total =~ ^[0-9]+$ ]] &&
+    ((split_num < split_total)); then
+    split_output=$(
+      echo $input_to_split |
+        tr ' ' '\n' |
+        sort |
+        awk "NR%${split_total}==${split_num}" |
+        tr '\n' ' '
+    )
   else
-      echo "warning: illegal subset options: "  >&2
-      echo "split_num:      ${split_num}"       >&2
-      echo "split_total:    ${split_total}"     >&2
-      echo "returning full output."             >&2
+    echo "warning: illegal subset options: " >&2
+    echo "split_num:      ${split_num}" >&2
+    echo "split_total:    ${split_total}" >&2
+    echo "returning full output." >&2
   fi
   split_output=${split_output:-$input_to_split}
   eval $__result="'$split_output'"
- }
+}
 
 export -f pick_subset


### PR DESCRIPTION
Currently I get an `Argument list too long` error from any command that is run in a script which sources `variables.sh` in the m3db monorepo. The problem is that `variables.sh` sets an environment variable, `SRC`, which takes up most of the memory that the OS reserves for the environment and arguments when a command is run, resulting in the aforementioned error. `SRC` is set to the output of `find_dirs` which, as best as I can tell, just seeks to return the list of directories which contain Go source code. This commit, therefore, excludes directories within a `node_modules` directory to dramatically reduce the size of `SRC` when run in the m3db monorepo. `node_modules` is managed by `npm` and should be safe to exclude from the `SRC`, `vendor`, which contains Go dependencies, is also excluded for example.

Admittedly, I don't like the fact that I have to add another directory to exclude. I would much prefer to use the `go list` command which is capable of recursively finding all subdirectories which contain Go code from a given root directory. Unfortunately, it's exceedingly difficult to know what depends on `SRC` and the assumptions that are made so I felt this would approach would be the path of least resilience.