### PR TITLE
Revert "[cover] deprecate use of gotestcover (#89)"

### DIFF
--- a/gotestcover/LICENSE
+++ b/gotestcover/LICENSE
@@ -1,0 +1,7 @@
+Copyright (C) 2015 Pierre Durand
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/gotestcover/Makefile
+++ b/gotestcover/Makefile
@@ -1,0 +1,19 @@
+#/bin/bash
+
+setup:
+	go get -u -v github.com/golang/lint/golint
+	go get -v -t ./...
+
+check:
+	gofmt -d .
+	go tool vet .
+	golint
+
+coverage:
+	gotestcover -coverprofile=coverage.txt github.com/pierrre/gotestcover
+	go tool cover -html=coverage.txt -o=coverage.html
+	
+clean:
+	-rm coverage.txt
+	-rm coverage.html
+	gofmt -w .

--- a/gotestcover/README.md
+++ b/gotestcover/README.md
@@ -1,0 +1,19 @@
+# Go test cover with multiple packages support
+
+## Features
+- Coverage profile with multiple packages (`go test` doesn't support that)
+
+## Install
+`go get github.com/pierrre/gotestcover`
+
+## Usage
+```sh
+gotestcover -coverprofile=cover.out mypackage
+go tool cover -html=cover.out -o=cover.html
+```
+
+Run on multiple package with:
+- `package1 package2`
+- `package/...`
+
+Some `go test / build` flags are available.

--- a/gotestcover/gotestcover.go
+++ b/gotestcover/gotestcover.go
@@ -1,0 +1,294 @@
+// Package gotestcover provides multiple packages support for Go test cover.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+var (
+	// go build
+	flagA    bool
+	flagX    bool
+	flagRace bool
+	flagTags string
+
+	// go test
+	flagV            bool
+	flagCount        int
+	flagCPU          string
+	flagParallel     string
+	flagRun          string
+	flagShort        bool
+	flagTimeout      string
+	flagCoverMode    string
+	flagCoverProfile string
+
+	// custom
+	flagParallelPackages = runtime.GOMAXPROCS(0)
+
+	// GAE/Go
+	flagGoogleAppEngine bool
+)
+
+func main() {
+	err := run()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	err := parseFlags()
+	if err != nil {
+		return err
+	}
+	pkgArgs, flagArgs := parseArgs()
+	pkgs, err := resolvePackages(pkgArgs)
+	if err != nil {
+		return err
+	}
+	result, failed := runAllPackageTests(pkgs, flagArgs, func(out string) {
+		fmt.Print(out)
+	})
+	err = writeCoverProfile(result.coverage)
+	if err != nil {
+		return err
+	}
+	if failed {
+		return fmt.Errorf("test failed, packages with failures: %v", result.pkgsFail)
+	}
+	return nil
+}
+
+func parseFlags() error {
+	flag.BoolVar(&flagA, "a", flagA, "see 'go build' help")
+	flag.BoolVar(&flagX, "x", flagX, "see 'go build' help")
+	flag.BoolVar(&flagRace, "race", flagRace, "see 'go build' help")
+	flag.StringVar(&flagTags, "tags", flagTags, "see 'go build' help")
+
+	flag.BoolVar(&flagV, "v", flagV, "see 'go test' help")
+	flag.IntVar(&flagCount, "count", flagCount, "see 'go test' help")
+	flag.StringVar(&flagCPU, "cpu", flagCPU, "see 'go test' help")
+	flag.StringVar(&flagParallel, "parallel", flagParallel, "see 'go test' help")
+	flag.StringVar(&flagRun, "run", flagRun, "see 'go test' help")
+	flag.BoolVar(&flagShort, "short", flagShort, "see 'go test' help")
+	flag.StringVar(&flagTimeout, "timeout", flagTimeout, "see 'go test' help")
+	flag.StringVar(&flagCoverMode, "covermode", flagCoverMode, "see 'go test' help")
+	flag.StringVar(&flagCoverProfile, "coverprofile", flagCoverProfile, "see 'go test' help")
+
+	flag.IntVar(&flagParallelPackages, "parallelpackages", flagParallelPackages, "Number of package test run in parallel")
+
+	flag.BoolVar(&flagGoogleAppEngine, "gae", flagGoogleAppEngine, "Bool of Command exec in GAE/Go")
+
+	flag.Parse()
+	if flagCoverProfile == "" {
+		return fmt.Errorf("flag coverprofile must be set")
+	}
+	if flagParallelPackages < 1 {
+		return fmt.Errorf("flag parallelpackages must be greater than or equal to 1")
+	}
+	return nil
+}
+
+func parseArgs() (pkgArgs, flagArgs []string) {
+	args := flag.Args()
+	for i, a := range args {
+		if strings.HasPrefix(a, "-") {
+			return args[:i], args[i:]
+		}
+	}
+	return args, nil
+}
+
+func resolvePackages(pkgArgs []string) ([]string, error) {
+	cmdArgs := []string{"list"}
+	cmdArgs = append(cmdArgs, pkgArgs...)
+	cmdOut, err := runGoCommand(cmdArgs...)
+	if err != nil {
+		return nil, err
+	}
+	var pkgs []string
+	sc := bufio.NewScanner(bytes.NewReader(cmdOut))
+	for sc.Scan() {
+		pkgs = append(pkgs, sc.Text())
+	}
+	return pkgs, nil
+}
+
+type runAllPackageTestsResult struct {
+	coverage []byte
+	pkgsPass []string
+	pkgsFail []string
+}
+
+func runAllPackageTests(
+	pkgs []string,
+	flgs []string,
+	pf func(string),
+) (runAllPackageTestsResult, bool) {
+	pkgch := make(chan string)
+	type res struct {
+		pkg string
+		out string
+		cov []byte
+		err error
+	}
+	resch := make(chan res)
+	wg := new(sync.WaitGroup)
+	wg.Add(flagParallelPackages)
+	go func() {
+		for _, pkg := range pkgs {
+			pkgch <- pkg
+		}
+		close(pkgch)
+		wg.Wait()
+		close(resch)
+	}()
+	for i := 0; i < flagParallelPackages; i++ {
+		go func() {
+			for p := range pkgch {
+				out, cov, err := runPackageTests(p, flgs)
+				resch <- res{
+					pkg: p,
+					out: out,
+					cov: cov,
+					err: err,
+				}
+			}
+			wg.Done()
+		}()
+	}
+	var result runAllPackageTestsResult
+	for r := range resch {
+		if r.err == nil {
+			pf(r.out)
+			result.coverage = append(result.coverage, r.cov...)
+			result.pkgsPass = append(result.pkgsPass, r.pkg)
+		} else {
+			pf(r.err.Error())
+			result.pkgsFail = append(result.pkgsFail, r.pkg)
+		}
+	}
+	return result, len(result.pkgsFail) > 0
+}
+
+func runPackageTests(pkg string, flgs []string) (out string, cov []byte, err error) {
+	coverFile, err := ioutil.TempFile("", "gotestcover-")
+	if err != nil {
+		return "", nil, err
+	}
+	defer os.Remove(coverFile.Name())
+	defer coverFile.Close()
+	var args []string
+	args = append(args, "test")
+
+	if flagA {
+		args = append(args, "-a")
+	}
+	if flagX {
+		args = append(args, "-x")
+	}
+	if flagRace {
+		args = append(args, "-race")
+	}
+	if flagTags != "" {
+		args = append(args, "-tags", flagTags)
+	}
+
+	if flagV {
+		args = append(args, "-v")
+	}
+	if flagCount != 0 {
+		args = append(args, "-count", fmt.Sprint(flagCount))
+	}
+	if flagCPU != "" {
+		args = append(args, "-cpu", flagCPU)
+	}
+	if flagParallel != "" {
+		args = append(args, "-parallel", flagParallel)
+	}
+	if flagRun != "" {
+		args = append(args, "-run", flagRun)
+	}
+	if flagShort {
+		args = append(args, "-short")
+	}
+	if flagTimeout != "" {
+		args = append(args, "-timeout", flagTimeout)
+	}
+	args = append(args, "-cover")
+	if flagCoverMode != "" {
+		args = append(args, "-covermode", flagCoverMode)
+	}
+	args = append(args, "-coverprofile", coverFile.Name())
+
+	args = append(args, pkg)
+
+	args = append(args, flgs...)
+
+	cmdOut, err := runGoCommand(args...)
+	if err != nil {
+		return "", nil, err
+	}
+	cov, err = ioutil.ReadAll(coverFile)
+	if err != nil {
+		return "", nil, err
+	}
+	cov = removeFirstLine(cov)
+	return string(cmdOut), cov, nil
+}
+
+func writeCoverProfile(cov []byte) error {
+	if len(cov) == 0 {
+		return nil
+	}
+	buf := new(bytes.Buffer)
+	mode := flagCoverMode
+	if mode == "" {
+		if flagRace {
+			mode = "atomic"
+		} else {
+			mode = "set"
+		}
+	}
+	fmt.Fprintf(buf, "mode: %s\n", mode)
+	buf.Write(cov)
+	return ioutil.WriteFile(flagCoverProfile, buf.Bytes(), os.FileMode(0644))
+}
+
+func runGoCommand(args ...string) ([]byte, error) {
+	goCmd := "go"
+	if flagGoogleAppEngine {
+		goCmd = "goapp"
+	}
+	cmd := exec.Command(goCmd, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("command %s: %s\n%s", cmd.Args, err, out)
+	}
+	return out, nil
+}
+
+func removeFirstLine(b []byte) []byte {
+	out := new(bytes.Buffer)
+	sc := bufio.NewScanner(bytes.NewReader(b))
+	firstLine := true
+	for sc.Scan() {
+		if firstLine {
+			firstLine = false
+			continue
+		}
+		fmt.Fprintf(out, "%s\n", sc.Bytes())
+	}
+	return out.Bytes()
+}

--- a/gotestcover/gotestcover_test.go
+++ b/gotestcover/gotestcover_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseFlags(t *testing.T) {
+	os.Args = []string{"gotestcover",
+		"-v",
+		"-a",
+		"-x",
+		"-tags=foobar",
+		"-race",
+		"-cpu=4",
+		"-parallel=2",
+		"-run=abc",
+		"-short",
+		"-timeout=15s",
+		"-covermode=atomic",
+		"-parallelpackages=2",
+		"-coverprofile=cover.out",
+		"-gae",
+	}
+
+	err := parseFlags()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !flagV {
+		t.Errorf("flagV should be set to true")
+	}
+
+	if !flagA {
+		t.Errorf("flagA should be set to true")
+	}
+
+	if !flagX {
+		t.Errorf("flagX should be set to true")
+	}
+
+	if flagTags != "foobar" {
+		t.Errorf("flagCPU is not equal to foobar, got %s", flagTags)
+	}
+
+	if !flagRace {
+		t.Errorf("flagRace should be set to true")
+	}
+
+	if flagCPU != "4" {
+		t.Errorf("flagCPU is not equal to 4, got %s", flagCPU)
+	}
+
+	if flagParallel != "2" {
+		t.Errorf("flagParallel is not equal to 2, got %s", flagParallel)
+	}
+
+	if flagRun != "abc" {
+		t.Errorf("flagRun is not equal to 'abc', got %s", flagRun)
+	}
+
+	if !flagShort {
+		t.Errorf("flagShort should be set to true")
+	}
+
+	if flagTimeout != "15s" {
+		t.Errorf("flagTimeout is not equal to '15s', got %s", flagTimeout)
+	}
+
+	if flagCoverMode != "atomic" {
+		t.Errorf("flagCoverMode is not equal to 'atomic', got %s", flagCoverMode)
+	}
+
+	if flagParallelPackages != 2 {
+		t.Errorf("flagParallelPackages is not equal to '2', got %d", flagParallelPackages)
+	}
+
+	if flagCoverProfile != "cover.out" {
+		t.Errorf("flagCoverProfile is not equal to 'cover.out', got %s", flagCoverProfile)
+	}
+
+	if !flagGoogleAppEngine {
+		t.Errorf("flagGoogleAppEngine should be set to true")
+	}
+}

--- a/test-cover.sh
+++ b/test-cover.sh
@@ -8,7 +8,9 @@ EXCLUDE_FILE=${2:-.excludecoverage}
 LOG=${3:-test.log}
 CI_DIR=${4:-.}
 
-rm -f "$TARGET" &>/dev/null || true
+rm $TARGET &>/dev/null || true
+echo "mode: atomic" > $TARGET
+echo "" > $LOG
 
 DIRS=""
 for DIR in $SRC;
@@ -19,7 +21,7 @@ do
 done
 
 # defaults to all DIRS if the split vars are unset
-pick_subset "$DIRS" TESTS "$SPLIT_IDX" "$TOTAL_SPLITS"
+pick_subset "$DIRS" TESTS $SPLIT_IDX $TOTAL_SPLITS
 
 if [ "$NPROC" = "" ]; then
   NPROC=$(getconf _NPROCESSORS_ONLN)
@@ -29,14 +31,13 @@ echo "test-cover begin: concurrency $NPROC"
 
 PROFILE_REG="profile_reg.tmp"
 
-echo 'mode: atomic' > "$TARGET"
-echo "" > "$LOG"
-<<<"$TESTS" xargs -P $NPROC -n1 -I{} sh -c "go test -v -race -timeout 5m -covermode=atomic -coverprofile=${PROFILE_REG} {} && tail -n +2 $PROFILE_REG >> $TARGET"
-TEST_EXIT=$?
+TEST_FLAGS="-v -race -timeout 5m -covermode atomic"
+go run $CI_DIR/.ci/gotestcover/gotestcover.go $TEST_FLAGS -coverprofile $PROFILE_REG -parallelpackages $NPROC $TESTS | tee $LOG
+TEST_EXIT=${PIPESTATUS[0]}
 
-filter_cover_profile $PROFILE_REG "$TARGET" "$EXCLUDE_FILE"
+filter_cover_profile $PROFILE_REG $TARGET $EXCLUDE_FILE
 
 find . -not -path '*/vendor/*' | grep \\.tmp$ | xargs -I{} rm {}
 echo "test-cover result: $TEST_EXIT"
 
-exit "$TEST_EXIT"
+exit $TEST_EXIT


### PR DESCRIPTION
This reverts commit 323f860b6a669b26f8f4e0ca5f3ee5c4f8f6e94d.

I believe this change has been causing corruption in our coverage
reports due to races writing out results. Reverting until we have a
better solution.