### PR TITLE
[test] Allow finding source dirs w/ golist

### DIFF
--- a/test-cover.sh
+++ b/test-cover.sh
@@ -18,12 +18,19 @@ echo "mode: atomic" > $TARGET
 echo "" > $LOG
 
 DIRS=""
-for DIR in $SRC;
-do
-  if ls $DIR/*_test.go &> /dev/null; then
-    DIRS="$DIRS $DIR"
-  fi
-done
+# Depending on what version of Go is being used, callers may wish to use "go
+# list" or find target directories by looking for test files.
+if [[ "$TESTDIR_SOURCE_TYPE" == "golist" ]]; then
+  DIRS=$(go list ./...)
+else
+  for DIR in $SRC;
+  do
+    if ls $DIR/*_test.go &> /dev/null; then
+      DIRS="$DIRS $DIR"
+    fi
+  done
+fi
+
 
 # defaults to all DIRS if the split vars are unset
 pick_subset "$DIRS" TESTS $SPLIT_IDX $TOTAL_SPLITS


### PR DESCRIPTION
By default we find packages to test by searching for directories with files
ending in `_test.go`. This misses packages w/o tests that might still be broken,
but might be necessary behavior depending on whether the Go version being called
uses modules. This allows finding packages to test with `go list`. Eventually we
can make this the default behavior when the OSS monorepo is on go modules.