### PR TITLE
[docker] Skip tmp cleanup by default

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -13,7 +13,10 @@ CONFIG=${1:-"docker/images.json"}
 
 function cleanup() {
   docker system prune -f
-  find /tmp -name '*m3-docker' -print0 | xargs -0 rm -fv
+  # We may not have permissions to clean /tmp in some environments.
+  if [[ -n "$DO_TMP_CLEANUP" ]]; then
+    find /tmp -name '*m3-docker' -print0 | xargs -0 rm -fv
+  fi
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
We may not have permissions in many environments. Specifically, we don't
on new Buildkite hosts.