### PR TITLE
Disble checkptr.

### DIFF
--- a/process-cover-package.sh
+++ b/process-cover-package.sh
@@ -13,7 +13,7 @@ if [[ -n "$GO_BUILD_TAGS" ]]; then
   TAGS=("-tags" "${GO_BUILD_TAGS}")
 fi
 
-if ! go test "${TAGS[@]}" -v -race -timeout 5m -covermode=atomic -coverprofile="$OUT" "$1"; then
+if ! go test "${TAGS[@]}" -v -race -gcflags=all=-d=checkptr=0 -timeout 5m -covermode=atomic -coverprofile="$OUT" "$1"; then
   echo "FAILED $1" > "$OUT"
   exit 1
 fi

--- a/process-cover-package.sh
+++ b/process-cover-package.sh
@@ -13,7 +13,12 @@ if [[ -n "$GO_BUILD_TAGS" ]]; then
   TAGS=("-tags" "${GO_BUILD_TAGS}")
 fi
 
-if ! go test "${TAGS[@]}" -v -race -gcflags=all=-d=checkptr=0 -timeout 5m -covermode=atomic -coverprofile="$OUT" "$1"; then
+GCFLAGS=""
+if [ "$DISABLE_CHECKPTR" = "true" ]; then
+    GCFLAGS="-gcflags=all=-d=checkptr=0"
+fi
+
+if ! go test "${TAGS[@]}" -v -race $GCFLAGS -timeout 5m -covermode=atomic -coverprofile="$OUT" "$1"; then
   echo "FAILED $1" > "$OUT"
   exit 1
 fi


### PR DESCRIPTION
Allows disabling of `checkptr` feature in go 1.14 via `DISABLE_CHECKPTR` env var.