### PR TITLE
Optionally set -race for integration tests

### DIFF
--- a/test-integration.sh
+++ b/test-integration.sh
@@ -11,6 +11,7 @@ INTEGRATION_TIMEOUT=${INTEGRATION_TIMEOUT:-10m}
 COVERMODE=atomic
 SCRATCH_FILE=${COVERFILE}.tmp
 SRC_ROOT=${SRC_ROOT:-.}
+TEST_OPTS=${TEST_OPTS:-}
 
 if [ ! -d "${SRC_ROOT}/${DIR}" ]; then
   echo "No integrations tests found"
@@ -35,7 +36,7 @@ then
 fi
 
 # compile the integration test binary
-go test -test.c -test.tags=${TAGS} -test.covermode ${COVERMODE} \
+go test ${TEST_OPTS} -test.c -test.tags=${TAGS} -test.covermode ${COVERMODE} \
   -test.coverpkg $(go list ./$SRC_ROOT/... |  grep -v /vendor/ | paste -sd, -) ${SRC_ROOT}/${DIR}
 
 INTEGRATION_TEST="./integration.test"

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -11,7 +11,8 @@ INTEGRATION_TIMEOUT=${INTEGRATION_TIMEOUT:-10m}
 COVERMODE=atomic
 SCRATCH_FILE=${COVERFILE}.tmp
 SRC_ROOT=${SRC_ROOT:-.}
-TEST_OPTS=${TEST_OPTS:-}
+RACE=${RACE:-""}
+TEST_OPTS=""
 
 if [ ! -d "${SRC_ROOT}/${DIR}" ]; then
   echo "No integrations tests found"
@@ -33,6 +34,10 @@ then
   # NB: need to do this in two steps or the go compiler compiles the partial file and is :(
   generate_dummy_coverage_file integration integration > coverage_imports_file.out
   mv coverage_imports_file.out ${DUMMY_FILE_PATH}
+fi
+
+if [ -n "${RACE}" ]; then
+  TEST_OPTS="${TEST_OPTS} -race"
 fi
 
 # compile the integration test binary

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -12,7 +12,7 @@ COVERMODE=atomic
 SCRATCH_FILE=${COVERFILE}.tmp
 SRC_ROOT=${SRC_ROOT:-.}
 RACE=${RACE:-""}
-TEST_OPTS=""
+TEST_OPTS=()
 
 if [ ! -d "${SRC_ROOT}/${DIR}" ]; then
   echo "No integrations tests found"
@@ -37,11 +37,11 @@ then
 fi
 
 if [ -n "${RACE}" ]; then
-  TEST_OPTS="${TEST_OPTS} -race"
+  TEST_OPTS+=("-race")
 fi
 
 # compile the integration test binary
-go test ${TEST_OPTS} -test.c -test.tags=${TAGS} -test.covermode ${COVERMODE} \
+go test "${TEST_OPTS[@]}" -test.c -test.tags=${TAGS} -test.covermode ${COVERMODE} \
   -test.coverpkg $(go list ./$SRC_ROOT/... |  grep -v /vendor/ | paste -sd, -) ${SRC_ROOT}/${DIR}
 
 INTEGRATION_TEST="./integration.test"


### PR DESCRIPTION
This will be used by m3db to pass -race for some integration tests to
check for data races.

RACE=true make test-ci-integration-dbnode