### PR TITLE
Set PANIC_ON_INVARIANT_VIOLATED=true for all make targets

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -12,6 +12,7 @@ test_one_integration := .ci/test-one-integration.sh
 test_ci_integration  := .ci/test-integration.sh
 test_log             := test.log
 codecov_push         := .ci/codecov.sh
+export PANIC_ON_INVARIANT_VIOLATED = true
 
 
 .PHONY: validate-gopath


### PR DESCRIPTION
Tests should panic so we can catch any invariant violations before releasing