### PR TITLE
[docker] Add ability to tag images with commit SHA

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -8,6 +8,10 @@ M3 docker images are built according to the following policy:
 
 3. For all images, and for all releases, there will be an image tagged `${IMAGE}:${RELEASE}`.
 
+4. For all images, if the `PUSH_SHA_TAG` environment variable is set to `true`, `${IMAGE}:${SHA}`
+   will point to the latest build on `origin/master` for that image, where `$SHA` is the first 8
+   characters of the SHA of the commit.
+
 ## Builds
 
 This directory contains the  build scripts for building images according to the above policy, and is intended to be
@@ -18,7 +22,7 @@ pipeline at `.buildkite/image-release-pipeline.yml` of the calling repo.
 `images.json` has the config for each image, and the base
 repository comes from the environment variable `M3_DOCKER_REPO`. For example, with the following config:
 
-```
+```bash
 export M3_DOCKER_REPO=quay.io/m3
 ```
 


### PR DESCRIPTION
This commit updates the `docker/build.sh` script to push a tag with the first 8 characters of a commit's SHA when the `PUSH_SHA_TAG` environment variable is set.